### PR TITLE
Add JSON “Content-Type” header to postman generator

### DIFF
--- a/generators/spec/postman/generator.js
+++ b/generators/spec/postman/generator.js
@@ -86,7 +86,12 @@ module.exports.Generator = class Generator {
       ],
       request: {
         method: "POST",
-        header: [],
+        header: [
+          {
+            key: "Content-Type",
+            value: "application/json"
+          }
+        ],
         body: {
           mode: "raw",
           raw: this.utils.generateRequestExample(method, methodSchema.params)


### PR DESCRIPTION
I'm working with a server instance that require "application/json" content type so I have to added this header manually. And as we use JSON-RPC, I think it makes sense to add this header right?