### PR TITLE
fix(utils.js): fix instertion of pattern in table

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -153,6 +153,9 @@ exports.parsePropertyList = (name, schema) => {
         ([constraintName, constraintValue]) => constraintValue !== undefined
       )
       .reduce((accumulator, [constraintName, constraintValue]) => {
+        if (constraintName == "pattern") {
+          constraintValue = constraintValue.replace(/\|/g, "\\|");
+        }
         accumulator.push(`${constraintName}="${constraintValue}"`);
         return accumulator;
       }, [])


### PR DESCRIPTION
fix insertion of  a regex in the "pattern" field withing the Parameters
table in the documentation by escaping the char "|". If not, the char is
considered a colum partition of the table and the documentation gets
broken.

support anyOf