### PR TITLE
fix: chdir to dir of spec file to fix parsing error of refs

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -206,8 +206,9 @@ exports.resolveSchemaRefs = async (schema) => {
 };
 
 exports.loadSchema = (schemaPath) => {
+  const cwd = process.cwd();
   if (!path.isAbsolute(schemaPath)) {
-    schemaPath = path.join(process.cwd(), schemaPath);
+    schemaPath = path.join(cwd, schemaPath);
   }
 
   const jsonString = fs.readFileSync(schemaPath, {
@@ -216,7 +217,9 @@ exports.loadSchema = (schemaPath) => {
 
   const schema = jsonlint.parse(jsonString);
 
+  process.chdir(path.dirname(schemaPath));
   const resolvedSchema = exports.resolveSchemaRefs(schema);
+  process.chdir(cwd);
 
   return resolvedSchema;
 };


### PR DESCRIPTION
* Found error:
```shell
$ pwd
/home/foo/jsonrpc
$ jrgen docs-html sub/index.json
/home/foo/jsonrpc/node_modules/jrgen/src/utils.js:201                       
        throw error;             
        ^                                     
                                                                                                   
ResolverError: Error opening file "/home/foo/jsonrpc/methods/session/login.json" 
ENOENT: no such file or directory, open '/home/foo/jsonrpc/methods/session/login.json'          
    at ReadFileContext.callback (/home/foo/jsonrpc/node_modules/@apidevtools/json-schema-ref-parser/lib/resolvers/file.js:52:20)
    at FSReqCallback.readFileAfterOpen [as oncomplete] (fs.js:282:13) {
  code: 'ERESOLVER',                                                                               
  source: '/home/foo/jsonrpc/methods/session/login.json',                   
  path: null,                                
  toJSON: [Function: toJSON],                                                                      
  ioErrorCode: 'ENOENT',                                                                           
  [Symbol(nodejs.util.inspect.custom)]: [Function: inspect]                                        
}                                                                                                  
error Command failed with exit code 1.
```
* Project files
```
jsonrpc
|- sub
|  |- methods
|  |  |- session
|  |     |- login.json
|  |- index.json
|- node_modules
|- package.json
```